### PR TITLE
Change documentation theme to pydata-sphinx-theme

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,5 +4,6 @@ numba
 numpy
 pandas
 pint>=0.10.1
+pydata-sphinx-theme
 scipy
 toml

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -85,7 +85,7 @@ pygments_style = 'sphinx'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = 'pydata_sphinx_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/environment.yml
+++ b/environment.yml
@@ -29,13 +29,13 @@ dependencies:
   - pandas
   - pint>=0.10.1
   - pip
+  - pydata-sphinx-theme
   - pydocstyle
   - pylint
   - pytest
   - scikit-image>=0.16
   - scipy
   - sphinx
-  - sphinx_rtd_theme
   - toml
   - tqdm
   - twine


### PR DESCRIPTION
# Description

Changes documentation theme from the standard readthedocs theme to the Pydata one.

No testing is required. Changes to the docs dependencies is required.